### PR TITLE
API制限を有効にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ $ make docker-run
 
 ## client
 
+gRPC API
+
 ```
-$ go run cmd/client/main.go
+$ go run cmd/client/main.go -api-key API_KEY
+```
+
+JSON API
+
+```
+$ curl -H "x-api-key: API_KEY" -X POST http://HOST:PORT/v1/conversations
 ```
 
 ## deploy

--- a/api_config.yaml
+++ b/api_config.yaml
@@ -6,7 +6,3 @@ name: message-server.endpoints.grpc-message-service.cloud.goog
 title: Message gRPC API
 apis:
   - name: message.MessageService
-usage:
-  rules:
-    - selector: "*"
-      allow_unregistered_calls: true

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -2,22 +2,34 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 
 	pb "github.com/takatoshiono/grpc-message-service/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 func main() {
-	conn, err := grpc.Dial(":50101", grpc.WithInsecure())
+	key := flag.String("api-key", "", "API key")
+	flag.Parse()
+
+	conn, err := grpc.Dial("35.190.236.190:9000", grpc.WithInsecure())
 	if err != nil {
 		log.Fatalf("failed to dial: %v", err)
 	}
 	defer conn.Close()
 
+	ctx := context.Background()
+
+	if *key != "" {
+		log.Printf("Using API key: %s", *key)
+		ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("x-api-key", *key))
+	}
+
 	client := pb.NewMessageServiceClient(conn)
 	convReq := &pb.CreateConversationRequest{}
-	conversation, err := client.CreateConversation(context.Background(), convReq)
+	conversation, err := client.CreateConversation(ctx, convReq)
 	if err != nil {
 		log.Fatalf("failed to CraeteConversation(): %v", err)
 	}
@@ -28,7 +40,7 @@ func main() {
 		Sender:         "bob",
 		Body:           "This is bob. Hello alice.",
 	}
-	message, err := client.CreateMessage(context.Background(), messReq)
+	message, err := client.CreateMessage(ctx, messReq)
 	if err != nil {
 		log.Fatalf("failed to CreateMessage(): %v", err)
 	}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -14,7 +14,7 @@ func main() {
 	key := flag.String("api-key", "", "API key")
 	flag.Parse()
 
-	conn, err := grpc.Dial("35.190.236.190:9000", grpc.WithInsecure())
+	conn, err := grpc.Dial(":50101", grpc.WithInsecure())
 	if err != nil {
 		log.Fatalf("failed to dial: %v", err)
 	}


### PR DESCRIPTION
これまでgRPCサービスの前段にいるプロキシ(ESP, Extensible Service Proxy)によるAPI制限を無効にしていた(`allow_unregistered_calls: true`)けど、有効にします

そしてクライアントのコードからAPI keyを送信できるようにします

- [API キーで API アクセスを制限する  \|  gRPC を使用する Cloud Endpoints  \|  Google Cloud](https://cloud.google.com/endpoints/docs/grpc/restricting-api-access-with-api-keys-grpc)
- [API キーの使用  \|  ドキュメント  \|  Google Cloud](https://cloud.google.com/docs/authentication/api-keys#creating_an_api_key)