### PR TITLE
Save entities to the Google Cloud Datastore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.10 AS build
 
 RUN go get -u -v google.golang.org/grpc
+RUN go get -u -v github.com/google/uuid
 
 WORKDIR /go/src/github.com/takatoshiono/grpc-message-service
 COPY . .

--- a/README.md
+++ b/README.md
@@ -7,6 +7,21 @@ $ make docker-build
 $ make docker-run
 ```
 
+## server(not docker) with [Cloud Datastore Emulator](https://cloud.google.com/datastore/docs/tools/datastore-emulator)
+
+start emulator.
+
+```
+$ gcloud beta emulators datastore start
+```
+
+in another terminal.
+
+```
+$ $(gcloud beta emulators datastore env-init)
+$ make run-server
+```
+
 ## client
 
 gRPC API

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -47,4 +47,11 @@ func main() {
 		log.Fatalf("failed to CreateMessage(): %v", err)
 	}
 	log.Printf("created Message %v", message)
+
+	messesReq := &pb.GetMessagesRequest{Parent: conversation.Name}
+	messages, err := client.GetMessages(ctx, messesReq)
+	if err != nil {
+		log.Fatalf("failed to GetMessages: %v", err)
+	}
+	log.Printf("get Messages %v", messages)
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/ptypes"
-
 	pb "github.com/takatoshiono/grpc-message-service/proto"
 )
 
@@ -20,7 +19,11 @@ func (s *server) CreateConversation(ctx context.Context, in *pb.CreateConversati
 	return conversation, nil
 
 	//	c := entity.NewConversation()
-	//	r := cloud_datastore.NewConversationRepository()
+	//	r, err := cloud_datastore.NewConversationRepository()
+	//	if err != nil {
+	//		// FIXME: What should we do here?
+	//		log.Fatalf("Failed to create ConversationRepository: %v", err)
+	//	}
 	//	r.Save(c)
 	//
 	//	return &pb.Conversation{Id: c.Id, CreatedAt: c.CreatedAt}, nil

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strings"
 
@@ -34,18 +33,12 @@ func (s *server) CreateConversation(ctx context.Context, in *pb.CreateConversati
 }
 
 func (s *server) CreateMessage(ctx context.Context, in *pb.CreateMessageRequest) (*pb.Message, error) {
-	// parent must have a relative resource name of the Conversation.
-	parentNameParts := strings.Split(in.Parent, "/")
-	if !(len(parentNameParts) == 2 && parentNameParts[0] == "conversations") {
-		return nil, fmt.Errorf("parent not found: %s", in.Parent)
-	}
-
 	cRepo, err := cloud_datastore.NewConversationRepository()
 	if err != nil {
 		log.Fatalf("failed to create ConversationRepository: %v", err)
 	}
 
-	c, err := cRepo.Get(parentNameParts[1])
+	c, err := cRepo.Get(in.Parent)
 	if err != nil {
 		log.Fatalf("Failed to get conversation: %v", err)
 	}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"log"
 	"strings"
 
 	"github.com/golang/protobuf/ptypes"
+	"github.com/takatoshiono/grpc-message-service/entity"
 	pb "github.com/takatoshiono/grpc-message-service/proto"
+	"github.com/takatoshiono/grpc-message-service/repository/cloud_datastore"
 )
 
 type server struct{}
@@ -15,18 +18,18 @@ func NewMessageServer() *server {
 }
 
 func (s *server) CreateConversation(ctx context.Context, in *pb.CreateConversationRequest) (*pb.Conversation, error) {
-	conversation := &pb.Conversation{Name: "conversations/abc123", CreateTime: ptypes.TimestampNow()}
-	return conversation, nil
-
-	//	c := entity.NewConversation()
-	//	r, err := cloud_datastore.NewConversationRepository()
-	//	if err != nil {
-	//		// FIXME: What should we do here?
-	//		log.Fatalf("Failed to create ConversationRepository: %v", err)
-	//	}
-	//	r.Save(c)
-	//
-	//	return &pb.Conversation{Id: c.Id, CreatedAt: c.CreatedAt}, nil
+	c := entity.NewConversation()
+	r, err := cloud_datastore.NewConversationRepository()
+	if err != nil {
+		// FIXME: What should we do here?
+		log.Fatalf("Failed to create ConversationRepository: %v", err)
+	}
+	r.Save(c)
+	createTime, err := ptypes.TimestampProto(c.CreatedAt)
+	if err != nil {
+		log.Fatalf("Failed to create Timestamp proto: %v", err)
+	}
+	return &pb.Conversation{Name: c.Name(), CreateTime: createTime}, nil
 }
 
 func (s *server) CreateMessage(ctx context.Context, in *pb.CreateMessageRequest) (*pb.Message, error) {

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -18,6 +18,12 @@ func NewMessageServer() *server {
 func (s *server) CreateConversation(ctx context.Context, in *pb.CreateConversationRequest) (*pb.Conversation, error) {
 	conversation := &pb.Conversation{Name: "conversations/abc123", CreateTime: ptypes.TimestampNow()}
 	return conversation, nil
+
+	//	c := entity.NewConversation()
+	//	r := cloud_datastore.NewConversationRepository()
+	//	r.Save(c)
+	//
+	//	return &pb.Conversation{Id: c.Id, CreatedAt: c.CreatedAt}, nil
 }
 
 func (s *server) CreateMessage(ctx context.Context, in *pb.CreateMessageRequest) (*pb.Message, error) {

--- a/entity/conversation.go
+++ b/entity/conversation.go
@@ -1,0 +1,12 @@
+package entity
+
+import "time"
+
+type Conversation struct {
+	Id        string
+	CreatedAt int64
+}
+
+func NewConversation() *Conversation {
+	return &Conversation{Id: "abcd1234", CreatedAt: time.Now().Unix()}
+}

--- a/entity/conversation.go
+++ b/entity/conversation.go
@@ -1,12 +1,16 @@
 package entity
 
-import "time"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 type Conversation struct {
-	Id        string
+	ID        string
 	CreatedAt int64
 }
 
 func NewConversation() *Conversation {
-	return &Conversation{Id: "abcd1234", CreatedAt: time.Now().Unix()}
+	return &Conversation{ID: uuid.New().String(), CreatedAt: time.Now().Unix()}
 }

--- a/entity/conversation.go
+++ b/entity/conversation.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -13,4 +14,8 @@ type Conversation struct {
 
 func NewConversation() *Conversation {
 	return &Conversation{ID: uuid.New().String(), CreatedAt: time.Now()}
+}
+
+func (c *Conversation) Name() string {
+	return fmt.Sprintf("conversations/%s", c.ID)
 }

--- a/entity/conversation.go
+++ b/entity/conversation.go
@@ -8,9 +8,9 @@ import (
 
 type Conversation struct {
 	ID        string
-	CreatedAt int64
+	CreatedAt time.Time
 }
 
 func NewConversation() *Conversation {
-	return &Conversation{ID: uuid.New().String(), CreatedAt: time.Now().Unix()}
+	return &Conversation{ID: uuid.New().String(), CreatedAt: time.Now()}
 }

--- a/entity/message.go
+++ b/entity/message.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,4 +17,8 @@ type Message struct {
 
 func NewMessage(c Conversation, sender string, body string) *Message {
 	return &Message{ID: uuid.New().String(), ConversationID: c.ID, Sender: sender, Body: body, CreatedAt: time.Now()}
+}
+
+func (m *Message) Name() string {
+	return fmt.Sprintf("conversations/%s/messages/%s", m.ConversationID, m.ID)
 }

--- a/entity/message.go
+++ b/entity/message.go
@@ -11,9 +11,9 @@ type Message struct {
 	ConversationID string
 	Sender         string
 	Body           string
-	CreatedAt      int64
+	CreatedAt      time.Time
 }
 
 func NewMessage(c Conversation, sender string, body string) *Message {
-	return &Message{ID: uuid.New().String(), ConversationID: c.ID, Sender: sender, Body: body, CreatedAt: time.Now().Unix()}
+	return &Message{ID: uuid.New().String(), ConversationID: c.ID, Sender: sender, Body: body, CreatedAt: time.Now()}
 }

--- a/entity/message.go
+++ b/entity/message.go
@@ -1,0 +1,15 @@
+package entity
+
+import "time"
+
+type Message struct {
+	Id             string
+	ConversationId string
+	Sender         string
+	Body           string
+	CreatedAt      int64
+}
+
+func NewMessage(c Conversation, sender string, body string) *Message {
+	return &Message{Id: "m123", ConversationId: c.Id, Sender: sender, Body: body, CreatedAt: time.Now().Unix()}
+}

--- a/entity/message.go
+++ b/entity/message.go
@@ -1,15 +1,19 @@
 package entity
 
-import "time"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 type Message struct {
-	Id             string
-	ConversationId string
+	ID             string
+	ConversationID string
 	Sender         string
 	Body           string
 	CreatedAt      int64
 }
 
 func NewMessage(c Conversation, sender string, body string) *Message {
-	return &Message{Id: "m123", ConversationId: c.Id, Sender: sender, Body: body, CreatedAt: time.Now().Unix()}
+	return &Message{ID: uuid.New().String(), ConversationID: c.ID, Sender: sender, Body: body, CreatedAt: time.Now().Unix()}
 }

--- a/repository/cloud_datastore/client.go
+++ b/repository/cloud_datastore/client.go
@@ -1,0 +1,19 @@
+package cloud_datastore
+
+import (
+	"context"
+	"log"
+
+	"cloud.google.com/go/datastore"
+)
+
+const projectID = "grpc-message-service"
+
+func NewCloudDatastoreClient() *datastore.Client {
+	ctx := context.Background()
+	client, err := datastore.NewClient(ctx, projectID)
+	if err != nil {
+		log.Fatalf("Failed to create client: %v", err)
+	}
+	return client
+}

--- a/repository/cloud_datastore/client.go
+++ b/repository/cloud_datastore/client.go
@@ -9,11 +9,12 @@ import (
 
 const projectID = "grpc-message-service"
 
-func NewCloudDatastoreClient() *datastore.Client {
+func NewCloudDatastoreClient() (*datastore.Client, error) {
 	ctx := context.Background()
 	client, err := datastore.NewClient(ctx, projectID)
 	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
+		log.Printf("Failed to create client: %v", err)
+		return client, err
 	}
-	return client
+	return client, nil
 }

--- a/repository/cloud_datastore/conversation.go
+++ b/repository/cloud_datastore/conversation.go
@@ -9,20 +9,12 @@ import (
 	"github.com/takatoshiono/grpc-message-service/entity"
 )
 
-const projectID = "grpc-message-service"
-
 type ConversationRespository struct {
 	client *datastore.Client
 }
 
 func NewConversationRepository() *ConversationRespository {
-	ctx := context.Background()
-	client, err := datastore.NewClient(ctx, projectID)
-	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
-	}
-
-	return &ConversationRespository{client: client}
+	return &ConversationRespository{client: NewCloudDatastoreClient()}
 }
 
 func (r *ConversationRespository) Save(c *entity.Conversation) (*entity.Conversation, error) {
@@ -31,6 +23,7 @@ func (r *ConversationRespository) Save(c *entity.Conversation) (*entity.Conversa
 	_, err := r.client.Put(ctx, k, c)
 	if err != nil {
 		log.Fatalf("Failed to save conversation: %v", err)
+		return c, err
 	}
 	return c, nil
 }

--- a/repository/cloud_datastore/conversation.go
+++ b/repository/cloud_datastore/conversation.go
@@ -37,3 +37,18 @@ func (r *ConversationRespository) Save(e *entity.Conversation) (*entity.Conversa
 	}
 	return e, nil
 }
+
+func (r *ConversationRespository) Get(ID string) (*entity.Conversation, error) {
+	ctx := context.Background()
+	k := datastore.NameKey("Conversation", ID, nil)
+	c := new(conversation)
+	if err := r.client.Get(ctx, k, c); err != nil {
+		log.Printf("Failed to get conversation: %v", err)
+		return nil, err
+	}
+	return conversationEntity(ID, c), nil
+}
+
+func conversationEntity(ID string, c *conversation) *entity.Conversation {
+	return &entity.Conversation{ID: ID, CreatedAt: c.CreatedAt}
+}

--- a/repository/cloud_datastore/conversation.go
+++ b/repository/cloud_datastore/conversation.go
@@ -15,6 +15,7 @@ type ConversationRespository struct {
 }
 
 type conversation struct {
+	ID        string
 	CreatedAt time.Time
 }
 
@@ -28,8 +29,8 @@ func NewConversationRepository() (*ConversationRespository, error) {
 
 func (r *ConversationRespository) Save(e *entity.Conversation) (*entity.Conversation, error) {
 	ctx := context.Background()
-	k := datastore.NameKey("Conversation", e.ID, nil)
-	c := &conversation{CreatedAt: e.CreatedAt}
+	k := datastore.NameKey("Conversation", e.Name(), nil)
+	c := &conversation{ID: e.ID, CreatedAt: e.CreatedAt}
 	_, err := r.client.Put(ctx, k, c)
 	if err != nil {
 		log.Printf("Failed to save conversation: %v", err)
@@ -38,17 +39,13 @@ func (r *ConversationRespository) Save(e *entity.Conversation) (*entity.Conversa
 	return e, nil
 }
 
-func (r *ConversationRespository) Get(ID string) (*entity.Conversation, error) {
+func (r *ConversationRespository) Get(name string) (*entity.Conversation, error) {
 	ctx := context.Background()
-	k := datastore.NameKey("Conversation", ID, nil)
+	k := datastore.NameKey("Conversation", name, nil)
 	c := new(conversation)
 	if err := r.client.Get(ctx, k, c); err != nil {
 		log.Printf("Failed to get conversation: %v", err)
 		return nil, err
 	}
-	return conversationEntity(ID, c), nil
-}
-
-func conversationEntity(ID string, c *conversation) *entity.Conversation {
-	return &entity.Conversation{ID: ID, CreatedAt: c.CreatedAt}
+	return &entity.Conversation{ID: c.ID, CreatedAt: c.CreatedAt}, nil
 }

--- a/repository/cloud_datastore/conversation.go
+++ b/repository/cloud_datastore/conversation.go
@@ -3,6 +3,7 @@ package cloud_datastore
 import (
 	"context"
 	"log"
+	"time"
 
 	"cloud.google.com/go/datastore"
 
@@ -13,6 +14,10 @@ type ConversationRespository struct {
 	client *datastore.Client
 }
 
+type conversation struct {
+	CreatedAt time.Time
+}
+
 func NewConversationRepository() (*ConversationRespository, error) {
 	client, err := NewCloudDatastoreClient()
 	if err != nil {
@@ -21,13 +26,14 @@ func NewConversationRepository() (*ConversationRespository, error) {
 	return &ConversationRespository{client: client}, nil
 }
 
-func (r *ConversationRespository) Save(c *entity.Conversation) (*entity.Conversation, error) {
+func (r *ConversationRespository) Save(e *entity.Conversation) (*entity.Conversation, error) {
 	ctx := context.Background()
-	k := datastore.NameKey("Conversation", c.ID, nil)
+	k := datastore.NameKey("Conversation", e.ID, nil)
+	c := &conversation{CreatedAt: e.CreatedAt}
 	_, err := r.client.Put(ctx, k, c)
 	if err != nil {
 		log.Printf("Failed to save conversation: %v", err)
-		return c, err
+		return e, err
 	}
-	return c, nil
+	return e, nil
 }

--- a/repository/cloud_datastore/conversation.go
+++ b/repository/cloud_datastore/conversation.go
@@ -13,8 +13,12 @@ type ConversationRespository struct {
 	client *datastore.Client
 }
 
-func NewConversationRepository() *ConversationRespository {
-	return &ConversationRespository{client: NewCloudDatastoreClient()}
+func NewConversationRepository() (*ConversationRespository, error) {
+	client, err := NewCloudDatastoreClient()
+	if err != nil {
+		return nil, nil
+	}
+	return &ConversationRespository{client: client}, nil
 }
 
 func (r *ConversationRespository) Save(c *entity.Conversation) (*entity.Conversation, error) {
@@ -22,7 +26,7 @@ func (r *ConversationRespository) Save(c *entity.Conversation) (*entity.Conversa
 	k := datastore.NameKey("Conversation", c.Id, nil)
 	_, err := r.client.Put(ctx, k, c)
 	if err != nil {
-		log.Fatalf("Failed to save conversation: %v", err)
+		log.Printf("Failed to save conversation: %v", err)
 		return c, err
 	}
 	return c, nil

--- a/repository/cloud_datastore/conversation.go
+++ b/repository/cloud_datastore/conversation.go
@@ -23,7 +23,7 @@ func NewConversationRepository() (*ConversationRespository, error) {
 
 func (r *ConversationRespository) Save(c *entity.Conversation) (*entity.Conversation, error) {
 	ctx := context.Background()
-	k := datastore.NameKey("Conversation", c.Id, nil)
+	k := datastore.NameKey("Conversation", c.ID, nil)
 	_, err := r.client.Put(ctx, k, c)
 	if err != nil {
 		log.Printf("Failed to save conversation: %v", err)

--- a/repository/cloud_datastore/conversation.go
+++ b/repository/cloud_datastore/conversation.go
@@ -1,15 +1,36 @@
 package cloud_datastore
 
 import (
+	"context"
+	"log"
+
+	"cloud.google.com/go/datastore"
+
 	"github.com/takatoshiono/grpc-message-service/entity"
 )
 
-type ConversationRespository struct{}
+const projectID = "grpc-message-service"
+
+type ConversationRespository struct {
+	client *datastore.Client
+}
 
 func NewConversationRepository() *ConversationRespository {
-	return &ConversationRespository{}
+	ctx := context.Background()
+	client, err := datastore.NewClient(ctx, projectID)
+	if err != nil {
+		log.Fatalf("Failed to create client: %v", err)
+	}
+
+	return &ConversationRespository{client: client}
 }
 
 func (r *ConversationRespository) Save(c *entity.Conversation) (*entity.Conversation, error) {
+	ctx := context.Background()
+	k := datastore.NameKey("Conversation", c.Id, nil)
+	_, err := r.client.Put(ctx, k, c)
+	if err != nil {
+		log.Fatalf("Failed to save conversation: %v", err)
+	}
 	return c, nil
 }

--- a/repository/cloud_datastore/conversation.go
+++ b/repository/cloud_datastore/conversation.go
@@ -1,0 +1,15 @@
+package cloud_datastore
+
+import (
+	"github.com/takatoshiono/grpc-message-service/entity"
+)
+
+type ConversationRespository struct{}
+
+func NewConversationRepository() *ConversationRespository {
+	return &ConversationRespository{}
+}
+
+func (r *ConversationRespository) Save(c *entity.Conversation) (*entity.Conversation, error) {
+	return c, nil
+}

--- a/repository/cloud_datastore/message.go
+++ b/repository/cloud_datastore/message.go
@@ -22,8 +22,8 @@ func NewMessageRepository() (*MessageRepository, error) {
 
 func (r *MessageRepository) Save(m *entity.Message) (*entity.Message, error) {
 	ctx := context.Background()
-	parentKey := datastore.NameKey("Conversation", m.ConversationId, nil)
-	k := datastore.NameKey("Message", m.Id, parentKey)
+	parentKey := datastore.NameKey("Conversation", m.ConversationID, nil)
+	k := datastore.NameKey("Message", m.ID, parentKey)
 	_, err := r.client.Put(ctx, k, m)
 	if err != nil {
 		log.Printf("Failed to create message: %v", err)

--- a/repository/cloud_datastore/message.go
+++ b/repository/cloud_datastore/message.go
@@ -3,6 +3,7 @@ package cloud_datastore
 import (
 	"context"
 	"log"
+	"time"
 
 	"cloud.google.com/go/datastore"
 	"github.com/takatoshiono/grpc-message-service/entity"
@@ -10,6 +11,12 @@ import (
 
 type MessageRepository struct {
 	client *datastore.Client
+}
+
+type message struct {
+	Sender    string
+	Body      string
+	CreatedAt time.Time
 }
 
 func NewMessageRepository() (*MessageRepository, error) {
@@ -20,14 +27,15 @@ func NewMessageRepository() (*MessageRepository, error) {
 	return &MessageRepository{client: client}, nil
 }
 
-func (r *MessageRepository) Save(m *entity.Message) (*entity.Message, error) {
+func (r *MessageRepository) Save(e *entity.Message) (*entity.Message, error) {
 	ctx := context.Background()
-	parentKey := datastore.NameKey("Conversation", m.ConversationID, nil)
-	k := datastore.NameKey("Message", m.ID, parentKey)
+	parentKey := datastore.NameKey("Conversation", e.ConversationID, nil)
+	k := datastore.NameKey("Message", e.ID, parentKey)
+	m := &message{Sender: e.Sender, Body: e.Body, CreatedAt: e.CreatedAt}
 	_, err := r.client.Put(ctx, k, m)
 	if err != nil {
 		log.Printf("Failed to create message: %v", err)
-		return m, err
+		return e, err
 	}
-	return m, nil
+	return e, nil
 }

--- a/repository/cloud_datastore/message.go
+++ b/repository/cloud_datastore/message.go
@@ -14,6 +14,7 @@ type MessageRepository struct {
 }
 
 type message struct {
+	ID        string
 	Sender    string
 	Body      string
 	CreatedAt time.Time
@@ -29,9 +30,12 @@ func NewMessageRepository() (*MessageRepository, error) {
 
 func (r *MessageRepository) Save(e *entity.Message) (*entity.Message, error) {
 	ctx := context.Background()
-	parentKey := datastore.NameKey("Conversation", e.ConversationID, nil)
-	k := datastore.NameKey("Message", e.ID, parentKey)
-	m := &message{Sender: e.Sender, Body: e.Body, CreatedAt: e.CreatedAt}
+
+	c := entity.Conversation{ID: e.ConversationID}
+	parentKey := datastore.NameKey("Conversation", c.Name(), nil)
+
+	k := datastore.NameKey("Message", e.Name(), parentKey)
+	m := &message{ID: e.ID, Sender: e.Sender, Body: e.Body, CreatedAt: e.CreatedAt}
 	_, err := r.client.Put(ctx, k, m)
 	if err != nil {
 		log.Printf("Failed to create message: %v", err)

--- a/repository/cloud_datastore/message.go
+++ b/repository/cloud_datastore/message.go
@@ -43,3 +43,22 @@ func (r *MessageRepository) Save(e *entity.Message) (*entity.Message, error) {
 	}
 	return e, nil
 }
+
+func (r *MessageRepository) List(conversationName string) ([]*entity.Message, error) {
+	k := datastore.NameKey("Conversation", conversationName, nil)
+	q := datastore.NewQuery("Message").Ancestor(k)
+
+	ctx := context.Background()
+	var messages []*message
+	_, err := r.client.GetAll(ctx, q, &messages)
+	if err != nil {
+		log.Printf("Failed to get messages: %v", err)
+		return nil, err
+	}
+
+	entities := make([]*entity.Message, len(messages))
+	for i, m := range messages {
+		entities[i] = &entity.Message{ID: m.ID, Sender: m.Sender, Body: m.Body, CreatedAt: m.CreatedAt}
+	}
+	return entities, err
+}

--- a/repository/cloud_datastore/message.go
+++ b/repository/cloud_datastore/message.go
@@ -1,0 +1,29 @@
+package cloud_datastore
+
+import (
+	"context"
+	"log"
+
+	"cloud.google.com/go/datastore"
+	"github.com/takatoshiono/grpc-message-service/entity"
+)
+
+type MessageRepository struct {
+	client *datastore.Client
+}
+
+func NewMessageRepository() *MessageRepository {
+	return &MessageRepository{client: NewCloudDatastoreClient()}
+}
+
+func (r *MessageRepository) Save(m *entity.Message) (*entity.Message, error) {
+	ctx := context.Background()
+	parentKey := datastore.NameKey("Conversation", m.ConversationId, nil)
+	k := datastore.NameKey("Message", m.Id, parentKey)
+	_, err := r.client.Put(ctx, k, m)
+	if err != nil {
+		log.Fatalf("Failed to create message: %v", err)
+		return m, err
+	}
+	return m, nil
+}

--- a/repository/cloud_datastore/message.go
+++ b/repository/cloud_datastore/message.go
@@ -12,8 +12,12 @@ type MessageRepository struct {
 	client *datastore.Client
 }
 
-func NewMessageRepository() *MessageRepository {
-	return &MessageRepository{client: NewCloudDatastoreClient()}
+func NewMessageRepository() (*MessageRepository, error) {
+	client, err := NewCloudDatastoreClient()
+	if err != nil {
+		return nil, nil
+	}
+	return &MessageRepository{client: client}, nil
 }
 
 func (r *MessageRepository) Save(m *entity.Message) (*entity.Message, error) {
@@ -22,7 +26,7 @@ func (r *MessageRepository) Save(m *entity.Message) (*entity.Message, error) {
 	k := datastore.NameKey("Message", m.Id, parentKey)
 	_, err := r.client.Put(ctx, k, m)
 	if err != nil {
-		log.Fatalf("Failed to create message: %v", err)
+		log.Printf("Failed to create message: %v", err)
 		return m, err
 	}
 	return m, nil

--- a/repository/conversation.go
+++ b/repository/conversation.go
@@ -1,0 +1,7 @@
+package repository
+
+import "github.com/takatoshiono/grpc-message-service/entity"
+
+type ConversationRespository interface {
+	Save(*entity.Conversation) (*entity.Conversation, error)
+}

--- a/repository/conversation.go
+++ b/repository/conversation.go
@@ -3,5 +3,6 @@ package repository
 import "github.com/takatoshiono/grpc-message-service/entity"
 
 type ConversationRespository interface {
-	Save(*entity.Conversation) (*entity.Conversation, error)
+	Save(e *entity.Conversation) (*entity.Conversation, error)
+	Get(name string) (*entity.Conversation, error)
 }

--- a/repository/message.go
+++ b/repository/message.go
@@ -3,5 +3,6 @@ package repository
 import "github.com/takatoshiono/grpc-message-service/entity"
 
 type MessageRepository interface {
-	Save(m *entity.Message) (*entity.Message, error)
+	Save(e *entity.Message) (*entity.Message, error)
+	List(conversationName string) ([]*entity.Message, error)
 }

--- a/repository/message.go
+++ b/repository/message.go
@@ -1,0 +1,7 @@
+package repository
+
+import "github.com/takatoshiono/grpc-message-service/entity"
+
+type MessageRepository interface {
+	Save(m *entity.Message) (*entity.Message, error)
+}


### PR DESCRIPTION
### 何を解決するか
メッセージを永続化します。手段としては一定量まで無料で使えるという理由で[Google Cloud Datastore](https://cloud.google.com/datastore/)を使います

### アーキテクチャ

こんな作りにします

```
Entity <-- Repository(I/F) <-- Server
```

Repositoryはインターフェースで、実装としてCloudDatastore用のRepositoryを用意します

![image](https://user-images.githubusercontent.com/10000/44244582-a0283980-a20f-11e8-899c-cecdede4b18e.png)
https://docs.google.com/drawings/d/1K4j8-bUbYWD-BvclCIOiKTUS0Lr3iQnSxJX0hb9ztww/edit

同じ種類のデータ（例えばメッセージ）でも３種類のデータ形式がある

- protobuf(pb)のMessage
- entityのMessage
- datastoreのMessage

このうちentityだけがシステム内部の形式で、他は外界とのやりとりに使うデータ形式