### PR TITLE
Datastore emulator in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 $ docker-compose up --build
 ```
 
-## client
+### client
 
 gRPC API
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,11 @@
 # grpc-message-service
 
-## server
+## Development
+
+### server
 
 ```
-$ make docker-build
-$ make docker-run
-```
-
-## server(not docker) with [Cloud Datastore Emulator](https://cloud.google.com/datastore/docs/tools/datastore-emulator)
-
-start emulator.
-
-```
-$ gcloud beta emulators datastore start
-```
-
-in another terminal.
-
-```
-$ $(gcloud beta emulators datastore env-init)
-$ make run-server
+$ docker-compose up --build
 ```
 
 ## client
@@ -36,7 +22,7 @@ JSON API
 $ curl -H "x-api-key: API_KEY" -X POST http://HOST:PORT/v1/conversations
 ```
 
-## deploy
+## Deploy
 
 ### Prerequisites
 
@@ -44,6 +30,13 @@ $ curl -H "x-api-key: API_KEY" -X POST http://HOST:PORT/v1/conversations
 - Install [ghq](https://github.com/motemen/ghq)
 - Clone [googleapis/googleapis](https://github.com/googleapis/googleapis) using `ghq get`
 - Clone [google/protobuf](https://github.com/google/protobuf) using `ghq get`
+
+### Docker Image
+
+```
+$ make docker-build
+$ make deploy-image
+```
 
 ### Create cluster
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  app:
+    build: .
+    ports:
+      - 50101:50101
+    environment:
+      DATASTORE_EMULATOR_HOST: datastore:8081
+      DATASTORE_PROJECT_ID: grpc-message-service
+  datastore:
+    build: docker/datastore-emulator
+    volumes:
+      - datastore_data:/opt/datastore
+    ports:
+      - 8081:8081
+    environment:
+      CLOUDSDK_CORE_PROJECT: grpc-message-service
+volumes:
+  datastore_data:

--- a/docker/datastore-emulator/Dockerfile
+++ b/docker/datastore-emulator/Dockerfile
@@ -1,0 +1,14 @@
+FROM google/cloud-sdk:alpine
+
+ENV DATASTORE_DATA_DIR /opt/datastore
+ENV DATASTORE_PORT 8081
+
+RUN apk --update --no-cache add openjdk8-jre
+RUN gcloud components install beta cloud-datastore-emulator
+
+COPY start.sh .
+
+VOLUME ${DATASTORE_DATA_DIR}
+
+EXPOSE ${DATASTORE_PORT}
+ENTRYPOINT ["./start.sh"]

--- a/docker/datastore-emulator/start.sh
+++ b/docker/datastore-emulator/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+gcloud beta emulators datastore start \
+    --data-dir=${DATASTORE_DATA_DIR} \
+    --host-port=0.0.0.0:${DATASTORE_PORT}


### PR DESCRIPTION
fix #7 

### 何を解決するか

[dockerからcloud datastore emulatorを使いたい · Issue \#7 · takatoshiono/grpc\-message\-service](https://github.com/takatoshiono/grpc-message-service/issues/7)

使えるようにします

### 方法

[GoogleCloudPlatform/cloud\-sdk\-docker: Docker image with all the components of the Google Cloud SDK](https://github.com/GoogleCloudPlatform/cloud-sdk-docker)

1. これをベースイメージとしてdatastore-emulatorを起動するイメージを作る
2. docker composeで環境変数を指定してサーバーとdatastore-emulatorを起動する

これも参考にした
https://github.com/SingularitiesCR/datastore-emulator-docker
